### PR TITLE
Source-Repository の Location を修正

### DIFF
--- a/io-choice.cabal
+++ b/io-choice.cabal
@@ -25,4 +25,4 @@ Library
 
 Source-Repository head
   Type:                 git
-  Location:             git clone git://github.com/kazu-yamamoto/alternative-io
+  Location:             git clone git://github.com/kazu-yamamoto/io-choice


### PR DESCRIPTION
Source-Repository の Location として io-choice ではなく alternative-io が指定されていたので修正しました。
